### PR TITLE
Use &[T] instead of &Vec<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This port is not affiliated with MapBox in any way and no endorsement is implied
 
 ```rust
 extern crate earcutr;
-var triangles = earcutr::earcut(&vec![10,0, 0,50, 60,60, 70,10],&vec![],2);
+var triangles = earcutr::earcut(&[10,0, 0,50, 60,60, 70,10],&[],2);
 println!("{:?}",triangles);  // [1, 0, 3, 3, 2, 1]
 ```
 
@@ -31,7 +31,7 @@ Each group of three vertex indices in the resulting array forms a triangle.
 
 ```rust
 // triangulating a polygon with a hole
-earcutr::earcut(&vec![0.,0., 100.,0., 100.,100., 0.,100.,  20.,20., 80.,20., 80.,80., 20.,80.], &vec![4],2);
+earcutr::earcut(&[0.,0., 100.,0., 100.,100., 0.,100.,  20.,20., 80.,20., 80.,80., 20.,80.], &[4],2);
 // [3,0,4, 5,4,0, 3,4,7, 5,0,1, 2,3,7, 6,5,1, 2,7,6, 6,1,2]
 ```
 

--- a/benches/speedtest.rs
+++ b/benches/speedtest.rs
@@ -145,7 +145,7 @@ fn bench_indices_3d(bench: &mut Bencher) {
 
 fn bench_empty(bench: &mut Bencher) {
     bench.iter(|| {
-        let _indices = earcutr::earcut(&vec![], &vec![], 2);
+        let _indices = earcutr::earcut::<f32>(&[], &[], 2);
     })
 }
 

--- a/benches/speedtest.rs
+++ b/benches/speedtest.rs
@@ -98,7 +98,7 @@ fn load_json(testname: &str) -> (Vec<f64>, Vec<usize>, usize) {
 
 fn bench_quadrilateral(bench: &mut Bencher) {
     bench.iter(|| {
-        earcutr::earcut(&vec![10., 0., 0., 50., 60., 60., 70., 10.], &vec![], 2);
+        earcutr::earcut(&[10., 0., 0., 50., 60., 60., 70., 10.], &[], 2);
     });
 }
 
@@ -107,7 +107,7 @@ fn bench_hole(bench: &mut Bencher) {
     let h = vec![10., 10., 40., 10., 40., 40., 10., 40.];
     v.extend(h);
     bench.iter(|| {
-        earcutr::earcut(&v, &vec![4], 2);
+        earcutr::earcut(&v, &[4], 2);
     })
 }
 
@@ -124,8 +124,8 @@ fn bench_flatten(bench: &mut Bencher) {
 fn bench_indices_2d(bench: &mut Bencher) {
     bench.iter(|| {
         let _indices = earcutr::earcut(
-            &vec![10.0, 0.0, 0.0, 50.0, 60.0, 60.0, 70.0, 10.0],
-            &vec![],
+            &[10.0, 0.0, 0.0, 50.0, 60.0, 60.0, 70.0, 10.0],
+            &[],
             2,
         );
     })
@@ -134,10 +134,10 @@ fn bench_indices_2d(bench: &mut Bencher) {
 fn bench_indices_3d(bench: &mut Bencher) {
     bench.iter(|| {
         let _indices = earcutr::earcut(
-            &vec![
+            &[
                 10.0, 0.0, 0.0, 0.0, 50.0, 0.0, 60.0, 60.0, 0.0, 70.0, 10.0, 0.0,
             ],
-            &vec![],
+            &[],
             3,
         );
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,8 +260,8 @@ fn compare_x<T: Float + Display>(a: &Node<T>, b: &Node<T>) -> std::cmp::Ordering
 // without holes
 fn eliminate_holes<T: Float + Display>(
     ll: &mut LinkedLists<T>,
-    data: &Vec<T>,
-    hole_indices: &Vec<usize>,
+    data: &[T],
+    hole_indices: &[usize],
     inouter_node: NodeIdx,
 ) -> NodeIdx {
     let mut outer_node = inouter_node;
@@ -648,7 +648,7 @@ fn filter_points<T: Float + Display>(
 // create a circular doubly linked list from polygon points in the
 // specified winding order
 fn linked_list<T: Float + Display>(
-    data: &Vec<T>,
+    data: &[T],
     start: usize,
     end: usize,
     clockwise: bool,
@@ -664,7 +664,7 @@ fn linked_list<T: Float + Display>(
 // add new nodes to an existing linked list.
 fn linked_list_add_contour<T: Float + Display>(
     ll: &mut LinkedLists<T>,
-    data: &Vec<T>,
+    data: &[T],
     start: usize,
     end: usize,
     clockwise: bool,
@@ -747,8 +747,8 @@ fn point_in_triangle<T: Float + Display>(
 }
 
 pub fn earcut<T: Float + Display>(
-    data: &Vec<T>,
-    hole_indices: &Vec<usize>,
+    data: &[T],
+    hole_indices: &[usize],
     dims: usize,
 ) -> Vec<usize> {
     let outer_len = match hole_indices.len() {
@@ -1183,15 +1183,15 @@ fn split_bridge_polygon<T: Float + Display>(
 // return a percentage difference between the polygon area and its
 // triangulation area; used to verify correctness of triangulation
 pub fn deviation<T: Float + Display>(
-    data: &Vec<T>,
-    hole_indices: &Vec<usize>,
+    data: &[T],
+    hole_indices: &[usize],
     dims: usize,
-    triangles: &Vec<usize>,
+    triangles: &[usize],
 ) -> T {
     if DIM != dims {
         return T::nan();
     }
-    let mut indices = hole_indices.clone();
+    let mut indices = hole_indices.to_vec();
     indices.push(data.len() / DIM);
     let (ix, iy) = (indices.iter(), indices.iter().skip(1));
     let body_area = signed_area(&data, 0, indices[0] * DIM).abs();
@@ -1215,7 +1215,7 @@ pub fn deviation<T: Float + Display>(
     }
 }
 
-fn signed_area<T: Float + Display>(data: &Vec<T>, start: usize, end: usize) -> T {
+fn signed_area<T: Float + Display>(data: &[T], start: usize, end: usize) -> T {
     let i = (start..end).step_by(DIM);
     let j = (start..end).cycle().skip((end - DIM) - start).step_by(DIM);
     let zero = T::zero();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -153,8 +153,8 @@ fn area_test(filename: &str, expected_num_tris: usize, expected_deviation: f64) 
 #[test]
 fn test_indices_2d() {
     let indices = earcutr::earcut(
-        &vec![10.0, 0.0, 0.0, 50.0, 60.0, 60.0, 70.0, 10.0],
-        &vec![],
+        &[10.0, 0.0, 0.0, 50.0, 60.0, 60.0, 70.0, 10.0],
+        &[],
         2,
     );
     assert!(indices == vec![1, 0, 3, 3, 2, 1]);
@@ -164,10 +164,10 @@ fn test_indices_2d() {
 #[test]
 fn test_indices_3d() {
     let indices = earcutr::earcut(
-        &vec![
+        &[
             10.0, 0.0, 0.0, 0.0, 50.0, 0.0, 60.0, 60.0, 0.0, 70.0, 10.0, 0.0,
         ],
-        &vec![],
+        &[],
         3,
     );
     assert!(indices == vec![1, 0, 3, 3, 2, 1]);
@@ -176,7 +176,7 @@ fn test_indices_3d() {
 
 #[test]
 fn test_empty() {
-    let indices = earcutr::earcut::<f64>(&vec![], &vec![], 2);
+    let indices = earcutr::earcut::<f64>(&[], &[], 2);
     println!("{:?}", indices);
     assert!(indices.len() == 0);
 }


### PR DESCRIPTION
First of all, thank you for providing this port! The output of the algorithm is correct for our use-case.

I noticed that the input to `earcut` is a `&Vec<T>`. This type rarely makes sense (a slice is effectively a borrowed vector) and using `&[T]` allows the user to pass an existing slice (in our case a contiguous tensor) without first converting it to a `Vec` using `to_vec`.

This would be a breaking change but the good news is that it likely won't affect existing users since `Vec<T>` dereferences into `&[T]`