### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ license = "ISC"
 edition = "2021"
 
 [dependencies]
-itertools = "0.10"
+itertools = "0.11"
 num-traits = "0.2"
 
 [dev-dependencies]
-criterion = "0.4"
-serde = "1.0.80"
-serde_derive = "1.0.80"
-serde_json = "1.0.33"
+criterion = "0.5"
+serde = "1.0.188"
+serde_derive = "1.0.188"
+serde_json = "1.0.107"
 
 [[bench]]
 name = "speedtest"
@@ -22,5 +22,5 @@ harness = false
 
 # for profiling with standard tools, like
 # Valgrind's Callgrind or Perf
-[profile.release] 
+[profile.release]
 debug = true


### PR DESCRIPTION
I noticed in my dependency graph (via `geo`) a somewhat outdated version of `itertools` and would like to suggest bumping the dependencies.