### PR TITLE
Remove usages of `extern crate`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This port is not affiliated with MapBox in any way and no endorsement is implied
 ## Usage
 
 ```rust
-extern crate earcutr;
 var triangles = earcutr::earcut(&[10,0, 0,50, 60,60, 70,10],&[],2).unwrap();
 println!("{:?}",triangles);  // [1, 0, 3, 3, 2, 1]
 ```

--- a/benches/speedtest.rs
+++ b/benches/speedtest.rs
@@ -1,6 +1,3 @@
-extern crate earcutr;
-extern crate serde;
-extern crate serde_json;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::fs::File;
 use std::fs::OpenOptions;

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,6 +1,3 @@
-extern crate earcutr;
-extern crate serde;
-extern crate serde_json;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Read;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,3 @@
-extern crate earcutr;
-
-extern crate serde;
-extern crate serde_json;
-
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Read;


### PR DESCRIPTION
Since the crate is using the 2021 edition, the `extern crate` declarations can be removed.