### PR TITLE
deps: Remove dep on serde_derive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ num-traits = "0.2"
 
 [dev-dependencies]
 criterion = "0.5"
-serde = "1.0.188"
-serde_derive = "1.0.188"
+serde = "1.0.88"
 serde_json = "1.0.107"
 
 [[bench]]


### PR DESCRIPTION
This isn't used here, so we don't need a direct dependency on it.