### PR TITLE
clippy: Add missing semicolons where nothing is returned.

### DIFF
--- a/benches/speedtest.rs
+++ b/benches/speedtest.rs
@@ -102,7 +102,7 @@ fn bench_hole(criterion: &mut Criterion) {
     criterion.bench_function("bench_hole", |bench| {
         bench.iter(|| {
             let _ = black_box(earcutr::earcut(&v, &[4], 2));
-        })
+        });
     });
 }
 
@@ -114,7 +114,7 @@ fn bench_flatten(criterion: &mut Criterion) {
     criterion.bench_function("bench_flatten", |bench| {
         bench.iter(|| {
             let (_vertices, _holes, _dimensions) = black_box(earcutr::legacy::flatten(&v));
-        })
+        });
     });
 }
 
@@ -126,7 +126,7 @@ fn bench_indices_2d(criterion: &mut Criterion) {
                 &[],
                 2,
             ));
-        })
+        });
     });
 }
 
@@ -140,7 +140,7 @@ fn bench_indices_3d(criterion: &mut Criterion) {
                 &[],
                 3,
             ));
-        })
+        });
     });
 }
 
@@ -148,7 +148,7 @@ fn bench_empty(criterion: &mut Criterion) {
     criterion.bench_function("bench_empty", |bench| {
         bench.iter(|| {
             let _indices = black_box(earcutr::earcut::<f32>(&[], &[], 2));
-        })
+        });
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ impl<T: Float> LinkedLists<T> {
             lastidx = Some(self.insert_node((start + x_index) / DIM, Coord { x, y }, lastidx));
             if contour_minx > x {
                 contour_minx = x;
-                leftmost_idx = lastidx
+                leftmost_idx = lastidx;
             };
             if self.usehash {
                 self.min.y = vertices.0[y_index].min(self.min.y);
@@ -475,7 +475,7 @@ impl<'a, T: Float> Iterator for NodePairIterator<'a, T> {
             // only one branch, saves time
             self.pending_result = None;
         } else {
-            self.pending_result = Some((&self.ll.nodes[self.cur], nextref!(self.ll, self.cur)))
+            self.pending_result = Some((&self.ll.nodes[self.cur], nextref!(self.ll, self.cur)));
         }
         cur_result
     }
@@ -872,7 +872,7 @@ fn linked_list<T: Float>(
 ) -> Result<(LinkedLists<T>, LinkedListNodeIndex), Error> {
     let mut ll: LinkedLists<T> = LinkedLists::new(vertices.len() / DIM);
     if vertices.len() < 80 {
-        ll.usehash = false
+        ll.usehash = false;
     };
     let (last_idx, _) = ll.add_contour(vertices, start, end, clockwise)?;
     Ok((ll, last_idx))


### PR DESCRIPTION
This is from `clippy::semicolon_if_nothing_returned`.